### PR TITLE
fix a typo in help

### DIFF
--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -34,7 +34,7 @@ printLocalHelp = ->
                   -b LOCAL_ADDR         local binding address, default is 127.0.0.1
                   -l LOCAL_PORT         local port
                   -k PASSWORD           password
-                  -s METHOD             encryption method, for example, aes-256-cfb
+                  -m METHOD             encryption method, for example, aes-256-cfb
                   -c CONFIG             path to config file
                 """
 
@@ -47,7 +47,7 @@ printServerHelp = ->
                   -s SERVER_ADDR        server address
                   -p SERVER_PORT        server port
                   -k PASSWORD           password
-                  -s METHOD             encryption method, for example, aes-256-cfb
+                  -m METHOD             encryption method, for example, aes-256-cfb
                   -c CONFIG             path to config file
                 """
 


### PR DESCRIPTION
`-m method` not `-s method`
