### PR TITLE
utils: should output the err.stack

### DIFF
--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -122,7 +122,7 @@ exports.warn = (msg)->
   exports.log exports.WARN, msg 
   
 exports.error = (msg)->
-  exports.log exports.ERROR, msg
+  exports.log exports.ERROR, msg?.stack or msg
 
 exports.inetNtoa = (buf) ->
   buf[0] + "." + buf[1] + "." + buf[2] + "." + buf[3]


### PR DESCRIPTION
```
12 Jun 16:01:30 - 744ms TypeError: Cannot call method 'destroy' of null
12 Jun 16:01:30 - 773ms connecting 107.170.192.119:8388
12 Jun 16:01:31 - 32ms connecting 107.170.192.119:8388
12 Jun 16:01:32 - 451ms connecting 107.170.192.119:8388
12 Jun 16:01:32 - 481ms connecting 107.170.192.119:8388
12 Jun 16:01:33 - 549ms TypeError: Cannot call method 'destroy' of null
```

It's hard to trace the real error, then we just output the error.stack if exists, then we/users could collect more information, and post the postmortem here.
