### PR TITLE
local: refuse remote data after connection disconnected

### DIFF
--- a/src/local.coffee
+++ b/src/local.coffee
@@ -53,6 +53,7 @@ createServer = (serverAddr, serverPort, port, key, method, timeout, local_addres
      
   server = net.createServer((connection) ->
     connections += 1
+    connected = true
     encryptor = new Encryptor(key, method)
     stage = 0
     headerLength = 0
@@ -153,6 +154,7 @@ createServer = (serverAddr, serverPort, port, key, method, timeout, local_addres
             utils.debug "stage = 5"
           )
           remote.on "data", (data) ->
+            return if !connected     # returns when connection disconnected
             utils.log utils.EVERYTHING, "remote on data"
             try
               if encryptor
@@ -216,6 +218,7 @@ createServer = (serverAddr, serverPort, port, key, method, timeout, local_addres
         connection.pause() unless remote.write(data)
   
     connection.on "end", ->
+      connected = false
       utils.debug "connection on end"
       remote.end()  if remote
   
@@ -224,6 +227,7 @@ createServer = (serverAddr, serverPort, port, key, method, timeout, local_addres
       utils.error "local error: #{e}"
 
     connection.on "close", (had_error)->
+      connected = false
       utils.debug "connection on close:#{had_error}"
       if had_error
         remote.destroy() if remote


### PR DESCRIPTION
fix this error:

```
12 Jun 21:33:35 - 549ms TypeError: Cannot call method 'destroy' of null
    at Socket.<anonymous> (/usr/local/lib/node_modules/shadowsocks/lib/shadowsocks/local.js:177:31)
    at Socket.EventEmitter.emit (events.js:95:17)
    at Socket.<anonymous> (_stream_readable.js:745:14)
    at Socket.EventEmitter.emit (events.js:92:17)
    at emitReadable_ (_stream_readable.js:407:10)
    at emitReadable (_stream_readable.js:403:5)
    at readableAddChunk (_stream_readable.js:165:9)
    at Socket.Readable.push (_stream_readable.js:127:10)
    at TCP.onread (net.js:528:21)
```

The reproduce description:
1. `connection` has been emitted at `close`
2. `clean` function is called
3. in this moment, `remote` stream still live, then the `data` event of `remote` might be called.

Such that from step 3, the below error would be created and caught by `try-catch` because `connection` has been set to `null` in `clean` function.
